### PR TITLE
Initialize bundler as it is intended

### DIFF
--- a/lib/ruby_on_etags/core.rb
+++ b/lib/ruby_on_etags/core.rb
@@ -90,10 +90,7 @@ module RubyOnEtags
 
     def gems_in_use
       if File.exists?("Gemfile")
-        # Bundler.load.specs
-        Bundler::Definition.build(Bundler.default_gemfile,
-                                  Bundler.default_lockfile,
-                                  nil).specs
+        Bundler.load.specs
       else
         []
       end


### PR DESCRIPTION
It takes more than Definition.build to properly initialize Bundler, it seems. Please take a look at Bundler#load -> Bundler#definition methods.

This fixes a bug, where bundler (invoked from roetags) fails to load gem specifications, if the gems are stored "locally" (e.g. in "vendor" folder).

(In the example below, "abstract" is located in "vendor" folder and "bundle check" says all dependencies are satisfied". However, calling "roetags build" fails to locate "abstract"):

$ roetags build
/home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.0.22/lib/bundler/spec_set.rb:88:in `block in materialize': Could not find abstract-1.0.0 in any of the sources (Bundler::GemNotFound)
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.0.22/lib/bundler/spec_set.rb:82:in`map!'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.0.22/lib/bundler/spec_set.rb:82:in `materialize'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/bundler-1.0.22/lib/bundler/definition.rb:107:in`specs'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/ruby_on_etags-0.1.3/lib/ruby_on_etags/core.rb:94:in `gems_in_use'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/ruby_on_etags-0.1.3/lib/ruby_on_etags/core.rb:55:in`build_tags_for_gems'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/ruby_on_etags-0.1.3/lib/ruby_on_etags/core.rb:49:in `build_tags'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/ruby_on_etags-0.1.3/lib/ruby_on_etags/cli.rb:10:in`build'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/invocation.rb:118:in`invoke_task'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/thor-0.14.6/lib/thor/base.rb:389:in`start'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/gems/ruby_on_etags-0.1.3/bin/roetags:4:in `<top (required)>'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/bin/roetags:19:in`load'
        from /home/cordawyn/.rvm/gems/ruby-1.9.2-p290/bin/roetags:19:in `<main>'
